### PR TITLE
Mark this repo as no longer maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Raft GRPC
 
+This project is **no longer maintained**. You might be interested in https://github.com/Jille/raft-grpc-transport instead.
+
 [![GoDoc Widget]][GoDoc] [![Go Report Card Widget]][Go Report Card]
 
 [GoDoc]: https://godoc.org/github.com/paralin/raft-grpc


### PR DESCRIPTION
and redirect people to https://github.com/Jille/raft-grpc-transport instead.